### PR TITLE
Deletion now ignores already deleted policies and Improved Error Handling 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 name: Release
 
 # This GitHub action creates a release when a tag that matches the pattern
-# "v*" (e.g. v0.1.0) is created.
+# 'v*' (e.g. v0.1.0) is created.
 on:
   push:
     tags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,11 +12,11 @@ builds:
       # usage by users in CI/CD systems like Terraform Cloud where
       # they are unable to install libraries.
       - CGO_ENABLED=0
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
       - freebsd
       - windows
@@ -24,38 +24,38 @@ builds:
       - darwin
     goarch:
       - amd64
-      - "386"
+      - '386'
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: "386"
-    binary: "{{ .ProjectName }}_v{{ .Version }}"
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-  - format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - formats: ['zip']
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
       # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
-      - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
-      - "--output"
-      - "${signature}"
-      - "--detach-sign"
-      - "${artifact}"
+      - '--batch'
+      - '--local-user'
+      - '{{ .Env.GPG_FINGERPRINT }}' # set this environment variable for your signing key
+      - '--output'
+      - '${signature}'
+      - '--detach-sign'
+      - '${artifact}'
 release:
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:

--- a/byteplus/common_error.go
+++ b/byteplus/common_error.go
@@ -19,7 +19,6 @@ const (
 	ERR_CODE_FAIL_TO_CONNECT              = "FailToConnect"
 	ERR_CODE_INTERNAL_SERVICE_TIMEOUT     = "InternalServiceTimeout"
 	ERR_CODE_SERVICE_UNAVAILABLE_TEMP     = "ServiceUnavailableTemp"
-
 	ERR_SERVICE_FAILURE                   = "ServiceFailure"
 	ERR_SERVICE_ACCESS_KEY_LIMIT_EXCEEDED = "ServiceAccessKeyLimitExceeded"
 )

--- a/byteplus/provider.go
+++ b/byteplus/provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/byteplus-sdk/byteplus-go-sdk-v2/byteplus"
 	"github.com/byteplus-sdk/byteplus-go-sdk-v2/byteplus/credentials"
 	"github.com/byteplus-sdk/byteplus-go-sdk-v2/byteplus/session"
-	"github.com/byteplus-sdk/byteplus-go-sdk-v2/service/iam"
+	byteplusIamClient "github.com/byteplus-sdk/byteplus-go-sdk-v2/service/iam"
 	byteplusBaseClient "github.com/byteplus-sdk/byteplus-sdk-golang/base"
 	byteplusCdnClient "github.com/byteplus-sdk/byteplus-sdk-golang/service/cdn"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -22,7 +22,7 @@ import (
 // Wrapper of Byteplus client
 type byteplusClients struct {
 	cdnClient *byteplusCdnClient.CDN
-	iamClient *iam.IAM
+	iamClient *byteplusIamClient.IAM
 }
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -206,7 +206,7 @@ func (p *byteplusProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	iamClient := iam.New(sess)
+	iamClient := byteplusIamClient.New(sess)
 
 	// Byteplus clients wrapper
 	byteplusClients := byteplusClients{

--- a/byteplus/resource_iam_policy.go
+++ b/byteplus/resource_iam_policy.go
@@ -210,7 +210,7 @@ func (r *iamPolicyResource) Read(ctx context.Context, req resource.ReadRequest, 
 		"error",
 		fmt.Sprintf("[API ERROR] Failed to Read Combined Policies for %v: Unexpected Error!", state.UserName),
 		readCombinedPolicyErr,
-		"This resource will be updated in the next terraform apply.",
+		"",
 	)
 
 	// Set state so that Terraform will trigger update if there are changes in state.


### PR DESCRIPTION
### ~/byteplus/resource_iam_policy.go

- In `Update()`, it will save state after `removePolicy()`, it also sets the `state.CombinePoliciesDetails` to nil
- Fixed Conversion Error in `combinePolicyDocument()`, where previously it will cause a `panic` when the statement is of type `list`
