### PR TITLE
Fix on data_source_cdn_domain fuzzy match.

### DIFF
--- a/byteplus/data_source_cdn_domain.go
+++ b/byteplus/data_source_cdn_domain.go
@@ -134,7 +134,7 @@ func (d *cdnDomainDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	// Create the request
 	ListCdnDomainsRequest := &byteplusCdnClient.ListCdnDomainsRequest{
-		Domain:   &domainName,
+		Domain:   byteplusCdnClient.GetStrPtr(fmt.Sprintf("%s$", domainName)),
 		PageNum:  &pageNum,
 		PageSize: &pageSize,
 	}

--- a/byteplus/data_source_cdn_domain.go
+++ b/byteplus/data_source_cdn_domain.go
@@ -134,7 +134,7 @@ func (d *cdnDomainDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	// Create the request
 	ListCdnDomainsRequest := &byteplusCdnClient.ListCdnDomainsRequest{
-		Domain:   byteplusCdnClient.GetStrPtr(fmt.Sprintf("%s$", domainName)),
+		Domain:   byteplusCdnClient.GetStrPtr(fmt.Sprintf("^%s$", domainName)),
 		PageNum:  &pageNum,
 		PageSize: &pageSize,
 	}


### PR DESCRIPTION
This PR fixes an issue in ListCdnDomains where the parameter `domain` fuzzy match is not handled properly. This update ensures proper handling by adding `$` in the end of `domain` indicating end of string for the search to prevent unintended matches.